### PR TITLE
UI-70: Split webpack configs

### DIFF
--- a/config/webpack.common.ts
+++ b/config/webpack.common.ts
@@ -33,33 +33,13 @@ const config: webpack.Configuration = {
       },
     ],
   },
-  // Enable served source maps
-  devtool: 'inline-source-map',
   resolve: {
     // Include all these extensions in processing (note we need .js because not all node_modules are .ts)
     extensions: ['.ts', '.tsx', '.js', '.css'],
   },
-  // Webpack Dev Server for running locally
-  devServer: {
-    // Play nicely with react-router
-    historyApiFallback: true,
-    port: 3000,
-    // Enable hot module reloading (HMR)
-    hot: true,
-    // Allow access via ngrok to local
-    disableHostCheck: true,
-  },
   plugins: [
     // Cleans the build folder per-build/reload
     new CleanWebpackPlugin(['dist']),
-    // HMR plugins
-    new webpack.NamedModulesPlugin(),
-    new webpack.HotModuleReplacementPlugin(),
-    // Prevents webpack watch from going into infinite loop (& stopping on retry) due to TS compilation
-    new webpack.WatchIgnorePlugin([
-      /\.js$/,
-      /\.d\.ts$/,
-    ]),
   ],
 };
 

--- a/config/webpack.deployment.ts
+++ b/config/webpack.deployment.ts
@@ -2,6 +2,7 @@ import * as HTMLPlugin from 'html-webpack-plugin';
 import common from './webpack.common';
 import * as webpack from 'webpack';
 import * as merge from 'webpack-merge';
+const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 
 const config: webpack.Configuration = {
   plugins: [
@@ -10,6 +11,7 @@ const config: webpack.Configuration = {
       template: 'INDEX_TEMPLATE.html',
       favicon: 'assets/favicon.ico',
     }),
+    new UglifyJSPlugin(),
   ]
 };
 

--- a/config/webpack.development.ts
+++ b/config/webpack.development.ts
@@ -6,6 +6,18 @@ import * as webpack from 'webpack';
 const Dotenv = require('dotenv-webpack');
 
 const config: webpack.Configuration = {
+  // Enable served source maps
+  devtool: 'inline-source-map',
+  // Webpack Dev Server for running locally
+  devServer: {
+    // Play nicely with react-router
+    historyApiFallback: true,
+    port: 3000,
+    // Enable hot module reloading (HMR)
+    hot: true,
+    // Allow access via ngrok to local
+    disableHostCheck: true,
+  },
   plugins: [
     new Dotenv({
       path: './env/.env.development',
@@ -18,6 +30,14 @@ const config: webpack.Configuration = {
       favicon: 'assets/favicon.ico',
       publicPath: '/',
     }),
+    // HMR plugins
+    new webpack.NamedModulesPlugin(),
+    new webpack.HotModuleReplacementPlugin(),
+    // Prevents webpack watch from going into infinite loop (& stopping on retry) due to TS compilation
+    new webpack.WatchIgnorePlugin([
+      /\.js$/,
+      /\.d\.ts$/,
+    ]),
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "ts-loader": "^4.0.0",
     "ts-node": "^5.0.0",
     "typescript": "^2.7.2",
+    "uglifyjs-webpack-plugin": "^1.2.4",
     "webpack": "^4.0.1",
     "webpack-cli": "^2.0.9",
     "webpack-dev-server": "^3.1.0",

--- a/src/components/strand/common/markdownRenderers.tsx
+++ b/src/components/strand/common/markdownRenderers.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import {Fragment, ReactType} from 'react';
+import Paper from 'material-ui/Paper';
+import Typography from 'material-ui/Typography';
+
+/*
+  Defaults:
+
+  root - Root container element that contains the rendered markdown
+  text - Text rendered inside of other elements, such as paragraphs
+    Probably don't want to edit this, as it affects everything within e.g. paragraph
+  break - Hard-break (<br>)
+  paragraph - Paragraph (<p>)
+  emphasis - Emphasis (<em>)
+  strong - Strong/bold (<strong>)
+  thematicBreak - Horizontal rule / thematic break (<hr>)
+  blockquote - Block quote (<blockquote>)
+  delete - Deleted/strike-through (<del>)
+  link - Link (<a>)
+  image - Image (<img>)
+  linkReference - Link (through a reference) (<a>)
+  imageReference - Image (through a reference) (<img>)
+  table - Table (<table>)
+  tableHead - Table head (<thead>)
+  tableBody - Table body (<tbody>)
+  tableRow - Table row (<tr>)
+  tableCell - Table cell (<td>/<th>)
+  list - List (<ul>/<ol>)
+  listItem - List item (<li>)
+  definition - Definition (not rendered by default)
+  heading - Heading (<h1>-<h6>)
+  inlineCode - Inline code (<code>)
+  code - Block of code (<pre><code>)
+  html - HTML node (Best-effort rendering)
+ */
+
+const renderers: {[nodeType: string]: ReactType} = {
+  'root': props => <Paper><div style={{padding: '1%'}}>{props.children}</div></Paper>,
+  'paragraph': ({children}) => <Fragment><Typography>{children}</Typography><br /></Fragment>,
+  'inlineCode': (props) => <code style={{color: 'red', borderStyle: 'solid', borderWidth: '1px', borderColor: 'lightgrey'}}>{props.children}</code>,
+  'code': (props) => <pre style={{backgroundColor: 'lightgray', borderStyle: 'solid', borderWidth: '1px'}}><code>{props.value}</code></pre>,
+  'listItem': (props) => (
+    <li>
+      {props.checked !== null
+        ? <input type="checkbox" readOnly checked={props.checked} />
+        : null}
+      <Typography>{props.children}</Typography>
+    </li>
+  )
+};
+
+export default renderers;

--- a/src/components/strand/rwd/StrandDetailViewDesktop.tsx
+++ b/src/components/strand/rwd/StrandDetailViewDesktop.tsx
@@ -5,6 +5,7 @@ import Grid from 'material-ui/Grid';
 import StrandViewHeader from '../common/StrandDetailViewHeader';
 import {GetStrandDetailStrandFragment} from '../../../../schema/graphql-types';
 import * as ReactMarkdown from 'react-markdown';
+import renderers from '../common/markdownRenderers';
 
 
 interface PropTypes {
@@ -20,7 +21,7 @@ class StrandViewDesktop extends Component<PropTypes> {
           <Divider style={{marginTop: '2.5%', marginBottom: '2.5%'}}/>
         </Grid>
         <Grid item style={{padding: '2% 2% 2% 2%', overflow: 'hidden'}}>
-          <ReactMarkdown source={this.props.strand.body}/>
+          <ReactMarkdown source={this.props.strand.body} renderers={renderers}/>
         </Grid>
       </Grid>
     );

--- a/src/components/strand/rwd/StrandDetailViewMobile.tsx
+++ b/src/components/strand/rwd/StrandDetailViewMobile.tsx
@@ -5,6 +5,7 @@ import Grid from 'material-ui/Grid';
 import StrandViewHeaderStacked from '../common/StrandDetailViewHeaderStacked';
 import {GetStrandDetailStrandFragment} from '../../../../schema/graphql-types';
 import * as ReactMarkdown from 'react-markdown';
+import renderers from '../common/markdownRenderers';
 
 interface PropTypes {
   strand: GetStrandDetailStrandFragment
@@ -20,7 +21,7 @@ class StrandDetailMobile extends Component<PropTypes> {
           <Divider style={{marginTop: '5vh', marginBottom: '5vh'}}/>
         </Grid>
         <Grid item>
-          <ReactMarkdown source={this.props.strand.body}/>
+          <ReactMarkdown source={this.props.strand.body} renderers={renderers}/>
         </Grid>
       </Grid>
     );

--- a/test/func/__snapshots__/viewingStrandDetail.test.ts.snap
+++ b/test/func/__snapshots__/viewingStrandDetail.test.ts.snap
@@ -5145,20 +5145,136 @@ exports[`viewing existing strand shows the user a filled out detail page when a 
                                       >
                                         <ReactMarkdown
                                           escapeHtml={true}
-                                          renderers={Object {}}
+                                          renderers={
+                                            Object {
+                                              "code": [Function],
+                                              "inlineCode": [Function],
+                                              "listItem": [Function],
+                                              "paragraph": [Function],
+                                              "root": [Function],
+                                            }
+                                          }
                                           skipHtml={false}
                                           source="Beatae eum at. Odio fuga quia. Minus qui eos velit voluptas vero fugiat. Enim facere mollitia exercitationem officiis."
                                           transformLinkUri={[Function]}
                                         >
-                                          <div
+                                          <root
                                             key="root-1-1"
                                           >
-                                            <p
-                                              key="paragraph-1-1"
-                                            >
-                                              Beatae eum at. Odio fuga quia. Minus qui eos velit voluptas vero fugiat. Enim facere mollitia exercitationem officiis.
-                                            </p>
-                                          </div>
+                                            <WithStyles(Paper)>
+                                              <Paper
+                                                classes={
+                                                  Object {
+                                                    "root": "MuiPaper-root-9",
+                                                    "rounded": "MuiPaper-rounded-10",
+                                                    "shadow0": "MuiPaper-shadow0-11",
+                                                    "shadow1": "MuiPaper-shadow1-12",
+                                                    "shadow10": "MuiPaper-shadow10-21",
+                                                    "shadow11": "MuiPaper-shadow11-22",
+                                                    "shadow12": "MuiPaper-shadow12-23",
+                                                    "shadow13": "MuiPaper-shadow13-24",
+                                                    "shadow14": "MuiPaper-shadow14-25",
+                                                    "shadow15": "MuiPaper-shadow15-26",
+                                                    "shadow16": "MuiPaper-shadow16-27",
+                                                    "shadow17": "MuiPaper-shadow17-28",
+                                                    "shadow18": "MuiPaper-shadow18-29",
+                                                    "shadow19": "MuiPaper-shadow19-30",
+                                                    "shadow2": "MuiPaper-shadow2-13",
+                                                    "shadow20": "MuiPaper-shadow20-31",
+                                                    "shadow21": "MuiPaper-shadow21-32",
+                                                    "shadow22": "MuiPaper-shadow22-33",
+                                                    "shadow23": "MuiPaper-shadow23-34",
+                                                    "shadow24": "MuiPaper-shadow24-35",
+                                                    "shadow3": "MuiPaper-shadow3-14",
+                                                    "shadow4": "MuiPaper-shadow4-15",
+                                                    "shadow5": "MuiPaper-shadow5-16",
+                                                    "shadow6": "MuiPaper-shadow6-17",
+                                                    "shadow7": "MuiPaper-shadow7-18",
+                                                    "shadow8": "MuiPaper-shadow8-19",
+                                                    "shadow9": "MuiPaper-shadow9-20",
+                                                  }
+                                                }
+                                                component="div"
+                                                elevation={2}
+                                                square={false}
+                                              >
+                                                <div
+                                                  className="MuiPaper-root-9 MuiPaper-shadow2-13 MuiPaper-rounded-10"
+                                                >
+                                                  <div
+                                                    style={
+                                                      Object {
+                                                        "padding": "1%",
+                                                      }
+                                                    }
+                                                  >
+                                                    <paragraph
+                                                      key="paragraph-1-1"
+                                                    >
+                                                      <WithStyles(Typography)>
+                                                        <Typography
+                                                          align="inherit"
+                                                          classes={
+                                                            Object {
+                                                              "alignCenter": "MuiTypography-alignCenter-82",
+                                                              "alignJustify": "MuiTypography-alignJustify-84",
+                                                              "alignLeft": "MuiTypography-alignLeft-81",
+                                                              "alignRight": "MuiTypography-alignRight-83",
+                                                              "body1": "MuiTypography-body1-78",
+                                                              "body2": "MuiTypography-body2-77",
+                                                              "button": "MuiTypography-button-80",
+                                                              "caption": "MuiTypography-caption-79",
+                                                              "colorError": "MuiTypography-colorError-92",
+                                                              "colorInherit": "MuiTypography-colorInherit-88",
+                                                              "colorPrimary": "MuiTypography-colorPrimary-89",
+                                                              "colorSecondary": "MuiTypography-colorSecondary-90",
+                                                              "colorTextSecondary": "MuiTypography-colorTextSecondary-91",
+                                                              "display1": "MuiTypography-display1-73",
+                                                              "display2": "MuiTypography-display2-72",
+                                                              "display3": "MuiTypography-display3-71",
+                                                              "display4": "MuiTypography-display4-70",
+                                                              "gutterBottom": "MuiTypography-gutterBottom-86",
+                                                              "headline": "MuiTypography-headline-74",
+                                                              "noWrap": "MuiTypography-noWrap-85",
+                                                              "paragraph": "MuiTypography-paragraph-87",
+                                                              "root": "MuiTypography-root-69",
+                                                              "subheading": "MuiTypography-subheading-76",
+                                                              "title": "MuiTypography-title-75",
+                                                            }
+                                                          }
+                                                          color="default"
+                                                          gutterBottom={false}
+                                                          headlineMapping={
+                                                            Object {
+                                                              "body1": "p",
+                                                              "body2": "aside",
+                                                              "display1": "h1",
+                                                              "display2": "h1",
+                                                              "display3": "h1",
+                                                              "display4": "h1",
+                                                              "headline": "h1",
+                                                              "subheading": "h3",
+                                                              "title": "h2",
+                                                            }
+                                                          }
+                                                          noWrap={false}
+                                                          paragraph={false}
+                                                          variant="body1"
+                                                        >
+                                                          <p
+                                                            className="MuiTypography-root-69 MuiTypography-body1-78"
+                                                          >
+                                                            Beatae eum at. Odio fuga quia. Minus qui eos velit voluptas vero fugiat. Enim facere mollitia exercitationem officiis.
+                                                          </p>
+                                                        </Typography>
+                                                      </WithStyles(Typography)>
+                                                      <br />
+                                                    </paragraph>
+                                                  </div>
+                                                </div>
+                                              </Paper>
+                                            </WithStyles(Paper)>
+                                          </root>
                                         </ReactMarkdown>
                                       </div>
                                     </Grid>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,7 +1702,7 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
-cacache@^10.0.1:
+cacache@^10.0.1, cacache@^10.0.4:
   version "10.0.4"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-10.0.4.tgz#6452367999eff9d4188aefd9a14e9d7c6a263460"
   dependencies:
@@ -8584,6 +8584,19 @@ uglifyjs-webpack-plugin@^1.1.1, uglifyjs-webpack-plugin@^1.2.2:
     cacache "^10.0.1"
     find-cache-dir "^1.0.0"
     schema-utils "^0.4.2"
+    serialize-javascript "^1.4.0"
+    source-map "^0.6.1"
+    uglify-es "^3.3.4"
+    webpack-sources "^1.1.0"
+    worker-farm "^1.5.2"
+
+uglifyjs-webpack-plugin@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.4.tgz#5eec941b2e9b8538be0a20fc6eda25b14c7c1043"
+  dependencies:
+    cacache "^10.0.4"
+    find-cache-dir "^1.0.0"
+    schema-utils "^0.4.5"
     serialize-javascript "^1.4.0"
     source-map "^0.6.1"
     uglify-es "^3.3.4"


### PR DESCRIPTION
Removed hot reloading from deployment

Removed sourcemaps from deployment

Uglified deployment


That cuts down production bundle size to about 800kb (from I think ~4.5mb), but that's still 4x the recommended 200kb. Added a ticket for a future optimization -- I think that'll require some lazy loading (or maybe there's some libs like moment/lodash that are crushing us).